### PR TITLE
Fix 1805

### DIFF
--- a/pkg/controllers/resources/nodes/syncer.go
+++ b/pkg/controllers/resources/nodes/syncer.go
@@ -55,6 +55,8 @@ func NewSyncer(ctx *synccontext.RegisterContext, nodeService nodeservice.NodeSer
 		}
 	}
 
+	edgewize.InitFakeNode(ctx)
+
 	return &nodeSyncer{
 		enableScheduler: ctx.Options.EnableScheduler,
 
@@ -141,23 +143,6 @@ func modifyController(ctx *synccontext.RegisterContext, nodeService nodeservice.
 	go func() {
 		nodeService.Start(ctx.Context)
 	}()
-	podList := &corev1.PodList{}
-	err := ctx.PhysicalManager.GetClient().List(ctx.Context, podList, &client.ListOptions{
-		LabelSelector: labels.SelectorFromSet(map[string]string{
-			"vcluster.loft.sh/managed-by": translate.Suffix,
-		}),
-	})
-	if err != nil {
-		klog.Errorf("error listing pods: %v", err)
-	} else {
-		klog.Infof("edgewize.FakeNodes found %d pods", len(podList.Items))
-		for _, pod := range podList.Items {
-			if pod.Spec.NodeName != "" {
-				edgewize.AddFakeNode(pod.Spec.NodeName)
-				klog.Infof("edgewize.FakeNodes added fake node %s", pod.Spec.NodeName)
-			}
-		}
-	}
 
 	return builder.Watches(source.NewKindWithCache(&corev1.Pod{}, ctx.PhysicalManager.GetCache()), handler.EnqueueRequestsFromMapFunc(func(object client.Object) []reconcile.Request {
 		pod, ok := object.(*corev1.Pod)

--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -130,6 +130,8 @@ func New(ctx *synccontext.RegisterContext) (syncer.Object, error) {
 	virtualLogsPath := filepath.Join(virtualPath, "log")
 	virtualKubeletPath := filepath.Join(virtualPath, "kubelet")
 
+	edgewize.InitFakeNode(ctx)
+
 	return &podSyncer{
 		NamespacedTranslator: namespacedTranslator,
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #https://github.com/kubesphere/issues/issues/1805


**Please provide a short message that should be published in the vcluster release notes**

## 背景
在新的架构中，虚拟节点不再是通过 label 判断，而是一个列表。
在之前的实现中，这个列表只会在从物理集群获取到含有 nodename 的 pod 时才会更新。

## 问题
当 vluster 服务重启时，此时由于 edgewize.fakenodes 未被初始化，所有对于node的判断均会判断为非fakenode。
![image](https://github.com/edgewize-io/edgewize-vcluster/assets/31612033/597ba73f-0d41-40d2-a5bf-f22b223705d5)

相关代码：
https://github.com/edgewize-io/edgewize-vcluster/blob/c826ae3e15a1579625d5cb7dfb65dcd368d40876/pkg/controllers/resources/pods/syncer.go#L437-L452

https://github.com/edgewize-io/edgewize-vcluster/blob/c826ae3e15a1579625d5cb7dfb65dcd368d40876/pkg/edgewize/edgewize.go#L31-L46

## 解决方案
在 node、pod 的sync初始化时进行列表初始化

相关PR ：https://github.com/edgewize-io/edgewize-vcluster/pull/7

**What else do we need to know?** 
