### PR TITLE
add fakenode label for whizard to distinguish fake nodes and edge nodes

### DIFF
--- a/pkg/controllers/resources/nodes/fake_syncer.go
+++ b/pkg/controllers/resources/nodes/fake_syncer.go
@@ -123,12 +123,13 @@ func CreateFakeNode(ctx context.Context, nodeServiceProvider nodeservice.NodeSer
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name.Name,
 			Labels: map[string]string{
-				"vcluster.loft.sh/fake-node": "true",
-				"beta.kubernetes.io/arch":    "amd64",
-				"beta.kubernetes.io/os":      "linux",
-				"kubernetes.io/arch":         "amd64",
-				"kubernetes.io/hostname":     translate.SafeConcatName("fake", name.Name),
-				"kubernetes.io/os":           "linux",
+				"vcluster.loft.sh/fake-node":       "true",
+				"beta.kubernetes.io/arch":          "amd64",
+				"beta.kubernetes.io/os":            "linux",
+				"kubernetes.io/arch":               "amd64",
+				"kubernetes.io/hostname":           translate.SafeConcatName("fake", name.Name),
+				"kubernetes.io/os":                 "linux",
+				"node-role.kubernetes.io/fakenode": "",
 			},
 			Annotations: map[string]string{
 				"node.alpha.kubernetes.io/ttl":                           "0",


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 

/kind feature


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves # https://github.com/kubesphere/issues/issues/2662


**Please provide a short message that should be published in the vcluster release notes**
为 vcluster 同步的 fakenode 自动打上 "node-role.kubernetes.io/fakenode" 标签，便于上游 whizard 组件区分 fake node 和普通节点数据


**What else do we need to know?** 
