### PR TITLE
fix issue 5009

### DIFF
--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -3,7 +3,6 @@ package pods
 import (
 	"context"
 	"fmt"
-	"k8s.io/klog/v2"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/edgewize"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
 
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer"
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
@@ -212,19 +212,23 @@ func (s *podSyncer) SyncDown(ctx *synccontext.SyncContext, vObj client.Object) (
 	vPod := vObj.(*corev1.Pod)
 
 	klog.Infof("Sync pod %s/%s down, node: %s", vPod.Namespace, vPod.Name, vPod.Spec.NodeName)
-	if vPod.Spec.NodeName != "" {
-		yes, err := edgewize.IsFakeNode(ctx.VirtualClient, vPod.Spec.NodeName)
-		if err != nil {
-			klog.Errorf("Failed to check if pod %s/%s is running on fake node: %v", vPod.Namespace, vPod.Name, err)
-			return ctrl.Result{}, err
-		}
-		if !yes {
-			klog.Infof("Skip sync pod %s/%s because it is not running on fake node", vPod.Namespace, vPod.Name)
-			return ctrl.Result{}, nil
-		}
+
+	if vPod.Spec.NodeName == "" {
+		klog.Infof("Skip sync pod %s/%s because it has no node name", vPod.Namespace, vPod.Name)
+		return ctrl.Result{}, nil
 	}
 
-	yes, err := edgewize.IsSystemWorkspace(ctx.VirtualClient, vPod.Namespace)
+	yes, err := edgewize.IsFakeNode(ctx.VirtualClient, vPod.Spec.NodeName)
+	if err != nil {
+		klog.Errorf("Failed to check if pod %s/%s is running on fake node: %v", vPod.Namespace, vPod.Name, err)
+		return ctrl.Result{}, err
+	}
+	if !yes {
+		klog.Infof("Skip sync pod %s/%s because it is not running on fake node", vPod.Namespace, vPod.Name)
+		return ctrl.Result{}, nil
+	}
+
+	yes, err = edgewize.IsSystemWorkspace(ctx.VirtualClient, vPod.Namespace)
 	if err != nil {
 		klog.Errorf("Failed to check if pod %s/%s is running on system namespace: %v", vPod.Namespace, vPod.Name, err)
 		return ctrl.Result{}, err
@@ -438,16 +442,19 @@ func (s *podSyncer) Sync(ctx *synccontext.SyncContext, pObj client.Object, vObj 
 	vPod := vObj.(*corev1.Pod)
 	pPod := pObj.(*corev1.Pod)
 
-	if vPod.Spec.NodeName != "" {
-		yes, err := edgewize.IsFakeNode(ctx.VirtualClient, vPod.Spec.NodeName)
-		if err != nil {
-			klog.Errorf("Failed to check if pod %s/%s is running on fake node: %v", vPod.Namespace, vPod.Name, err)
-			return ctrl.Result{}, err
-		}
-		if !yes {
-			klog.Infof("Skip sync pod %s/%s because it is not running on fake node", vPod.Namespace, vPod.Name)
-			return ctrl.Result{}, nil
-		}
+	if vPod.Spec.NodeName == "" {
+		klog.Infof("Skip sync pod %s/%s because it has no node name", vPod.Namespace, vPod.Name)
+		return ctrl.Result{}, nil
+	}
+
+	yes, err := edgewize.IsFakeNode(ctx.VirtualClient, vPod.Spec.NodeName)
+	if err != nil {
+		klog.Errorf("Failed to check if pod %s/%s is running on fake node: %v", vPod.Namespace, vPod.Name, err)
+		return ctrl.Result{}, err
+	}
+	if !yes {
+		klog.Infof("Skip sync pod %s/%s because it is not running on fake node", vPod.Namespace, vPod.Name)
+		return ctrl.Result{}, nil
 	}
 
 	// should pod get deleted?


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #https://github.com/kubesphere/project/issues/5009


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...
![企业微信截图_3e045b11-abd5-48bb-b8af-7e4f038b3d21](https://github.com/user-attachments/assets/aceb8552-43ac-4fbc-a89b-286d9434a20a)
pod在刚创建时时没有nodeName的，这时可能会被同步到meta集群

**What else do we need to know?** 
关联 commit  https://github.com/edgewize-io/edgewize-vcluster/commit/ce12b668f0c790ac60564f3b2c70d407e6f73dde